### PR TITLE
Fix login/register redirect and logout handling

### DIFF
--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -7,10 +7,10 @@ import { SmartDashboard } from "@/components/futuristic/smart-dashboard";
 import { QuantumPortal } from "@/components/futuristic/quantum-portal";
 
 export default function Home() {
-  const { user, clearAuth } = useAuthStore();
+  const { user, logout } = useAuthStore();
 
   const handleLogout = () => {
-    clearAuth();
+    logout();
   };
 
   return (

--- a/client/src/pages/landing.tsx
+++ b/client/src/pages/landing.tsx
@@ -46,7 +46,7 @@ export default function Landing() {
         email: data.email,
         password: data.password,
       });
-      return response;
+      return response.json();
     },
     onSuccess: (data) => {
       setAuth(data.user, data.accessToken);
@@ -72,7 +72,7 @@ export default function Landing() {
         password: data.password,
         name: data.name || data.email.split("@")[0],
       });
-      return response;
+      return response.json();
     },
     onSuccess: (data) => {
       setAuth(data.user, data.accessToken);


### PR DESCRIPTION
## Summary
- Parse JSON responses for login and registration on landing page to set auth and redirect correctly
- Use logout from auth store on home page to avoid runtime errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors about missing types and properties)*

------
https://chatgpt.com/codex/tasks/task_b_68a646b673488329887ad38aa598c28a